### PR TITLE
More flexibility for external code analysis tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,288 +1,357 @@
 {
   "name": "vscode-s-quirrel",
-  "version": "0.0.4",
-  "lockfileVersion": 1,
+  "version": "0.0.8",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@babel/code-frame": {
+  "packages": {
+    "": {
+      "name": "vscode-s-quirrel",
+      "version": "0.0.8",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^10.17.19",
+        "@types/vscode": "^1.43.0",
+        "tslint": "^5.16.0",
+        "typescript": "^3.8.3"
+      },
+      "engines": {
+        "vscode": "^1.43.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
       "integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@babel/highlight": "^7.8.0"
       }
     },
-    "@babel/highlight": {
+    "node_modules/@babel/highlight": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
       "integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "10.17.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
       "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==",
       "dev": true
     },
-    "@types/vscode": {
+    "node_modules/@types/vscode": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
       "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
       "dev": true
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "argparse": {
+    "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "builtin-modules": {
+    "node_modules/builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-name": "1.1.3"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "commander": {
+    "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "diff": {
+    "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
-    "escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "esprima": {
+    "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "esutils": {
+    "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "js-tokens": {
+    "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "js-yaml": {
+    "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-parse": {
+    "node_modules/path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "resolve": {
+    "node_modules/resolve": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
       "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "semver": {
+    "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "sprintf-js": {
+    "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "tslib": {
+    "node_modules/tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
-    "tslint": {
+    "node_modules/tslint": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
       "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
@@ -296,24 +365,43 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "bin": {
+        "tslint": "bin/tslint"
+      },
+      "engines": {
+        "node": ">=4.8.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
       }
     },
-    "tsutils": {
+    "node_modules/tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "tslib": "^1.8.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-s-quirrel",
   "displayName": "(S)quirrel",
   "description": "Squirrel and Quirrel language support",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "mepsoid",
   "icon": "acorn.png",
   "license": "MIT",
@@ -37,10 +37,15 @@
     "configuration": {
       "title": "(S)quirrel",
       "properties": {
+        "squirrel.codeAnalysis.command": {
+          "type": "string",
+          "default": "csq-dev --static-analysis --message-output-file:$DIAG_JSON $SRC_FILE",
+          "markdownDescription": "Identifier of environment variable that contains a command line of code runner utility, or command line of a code runner utility. Parameters are: **DIAG_JSON** - name of a temporary file to write diagnostic results to, **SRC_FILE** - name of the file to process. If not empty, this overrides **squirrel.syntaxChecker.fileName**."
+        },
         "squirrel.syntaxChecker.fileName": {
           "type": "string",
           "default": "sq3_static_analyzer-dev",
-          "markdownDescription": "Identifier of environment variable that contains full path to syntax checking utility, or full path to syntax checking utility, or executable file name that must be discoverable through system **PATH** variable."
+          "markdownDescription": "Identifier of environment variable that contains full path to syntax checking utility, or full path to syntax checking utility, or executable file name that must be discoverable through system **PATH** variable. This is deprecated, use **Code Analysis** tool since it is more flexible."
         },
         "squirrel.codeRunner.fileName": {
           "type": "string",

--- a/src/checkSyntaxOnSave.ts
+++ b/src/checkSyntaxOnSave.ts
@@ -1,6 +1,10 @@
 import * as vs from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
 import { exec } from 'child_process';
 import syntaxDiags from './syntaxDiags';
+import { dbgOutputChannel } from './utils';
 
 type DiagnosticItem = {
   line: number;
@@ -20,6 +24,34 @@ const ERRORCODE_UNUSED = [213, 221, 228];
 
 const versionControl: {[key: string]: number;} = {};
 
+function processDiagOutput(diagOutput: string | null, document: vs.TextDocument) {
+  if (diagOutput == null) {
+    syntaxDiags.delete(document.uri);
+    return;
+  }
+
+  const result: DiagnosticResult = JSON.parse(diagOutput);
+  const messages = result?.messages || [];
+
+  const diagList: vs.Diagnostic[] = messages.map((msg) => {
+    const line = msg.line - 1;
+    const col = msg.col - 1;
+    const range = new vs.Range(line, col, line, col + msg.len);
+    const severity = msg.isError
+      ? vs.DiagnosticSeverity.Error
+      : vs.DiagnosticSeverity.Warning;
+    const errorCode = msg.intId;
+    const diag = new vs.Diagnostic(range, msg.message, severity);
+    diag.code = [errorCode, msg.textId].join(':');
+    diag.source = DIAGNOSTIC_SOURCE;
+    if (ERRORCODE_UNUSED.indexOf(errorCode) >= 0)
+      diag.tags = [vs.DiagnosticTag.Unnecessary];
+    return diag;
+  });
+  syntaxDiags.set(document.uri, diagList);
+}
+
+
 export default function checkSyntaxOnSave(document: vs.TextDocument) {
   if (document.languageId !== 'squirrel')
     return;
@@ -30,41 +62,57 @@ export default function checkSyntaxOnSave(document: vs.TextDocument) {
     return;
   versionControl[srcPath] = version;
 
-  const config = vs.workspace.getConfiguration('squirrel.syntaxChecker');
-  let toolPath: string = config.get('fileName') || '';
-  toolPath = process.env[toolPath] || toolPath;
-  let cmd: string = `${toolPath} --message-output-file: ${srcPath}`;
+  const codeAnalysisConfig = vs.workspace.getConfiguration('squirrel.codeAnalysis');
+  let analysisCommand: string = codeAnalysisConfig.get('command') || '';
+  analysisCommand = process.env[analysisCommand] || analysisCommand;
+  if (analysisCommand.trim() !== '') {
+    // use arbitrary source code analysis tool
+    const tempFilePath = path.join(os.tmpdir(), 'quirrel-diag.json');
+    analysisCommand = analysisCommand.replace(/\$SRC_FILE/g, srcPath);
+    analysisCommand = analysisCommand.replace(/\$DIAG_JSON/g, tempFilePath);
 
-  exec(cmd, (error, stdout, stderr) => {
-    if (stderr) {
-      // TODO diagnose analyzer execution failure
-      syntaxDiags.delete(document.uri);
-      return;
-    }
+    fs.unlinkSync(tempFilePath);
 
-    if (error && !stdout) {
-      // TODO diagnose different errorlevels
-      syntaxDiags.clear();
-      return;
-    }
+    dbgOutputChannel.appendLine("Executing: " + analysisCommand);
 
-    const result: DiagnosticResult = JSON.parse(stdout);
-    const messages = result?.messages || [];
-    const diagList: vs.Diagnostic[] = messages.map((msg) => {
-      const line = msg.line - 1;
-      const col = msg.col - 1;
-      const range = new vs.Range(line, col, line, col + msg.len);
-      const severity = msg.isError
-        ? vs.DiagnosticSeverity.Error
-        : vs.DiagnosticSeverity.Warning;
-      const errorCode = msg.intId;
-      const diag = new vs.Diagnostic(range, msg.message, severity);
-      diag.code = [errorCode, msg.textId].join(':');
-      diag.source = DIAGNOSTIC_SOURCE;
-      if (ERRORCODE_UNUSED.indexOf(errorCode) >= 0)
-        diag.tags = [vs.DiagnosticTag.Unnecessary];
-      return diag;
+    exec(analysisCommand, (error, stdout, stderr) => {
+      // Ignore return code, check only output file, since found errors are not a failure
+
+      fs.readFile(tempFilePath, 'utf8', (err, data) => {
+        if (err) {
+          dbgOutputChannel.appendLine("Error reading file: " + err.message);
+          // TODO diagnose file reading failure
+          processDiagOutput(null, document);
+        }
+        else {
+          processDiagOutput(data, document);
+        }
+      });
     });
-    syntaxDiags.set(document.uri, diagList);
-  });
+
+    fs.unlinkSync(tempFilePath);
+  }
+  else {
+    // use arbitrary legacy static analyser
+    const syntaxCheckerConfig = vs.workspace.getConfiguration('squirrel.syntaxChecker');
+    let toolPath: string = syntaxCheckerConfig.get('fileName') || '';
+    toolPath = process.env[toolPath] || toolPath;
+    let cmd: string = `${toolPath} --message-output-file: ${srcPath}`;
+
+    exec(cmd, (error, stdout, stderr) => {
+      let diagOutput:string|null = null;
+
+      if (stderr) {
+        // TODO diagnose analyzer execution failure
+      }
+      else if (error && !stdout) {
+        // TODO diagnose different errorlevels
+      }
+      else {
+        diagOutput = stdout;
+      }
+
+      processDiagOutput(diagOutput, document);
+    });
+  }
 }

--- a/src/runDocumentCode.ts
+++ b/src/runDocumentCode.ts
@@ -1,10 +1,9 @@
 import * as vs from 'vscode';
 import { exec } from 'child_process';
 import syntaxDiags from './syntaxDiags';
+import { dbgOutputChannel } from './utils';
 
 const DIAGNOSTIC_SOURCE = 'Code runner';
-
-const channel = vs.window.createOutputChannel("Squirrel");
 
 function checkCompileError(diagList: vs.Diagnostic[], message: string) {
   const pattern = /line = \((\d+)\).*column = \((\d+)\).*:\s*(.*)/gi;
@@ -44,8 +43,8 @@ export default function runDocumentCode() {
 
   const document = editor.document;
   const srcPath = document.uri.fsPath;
-  channel.show(true);
-  channel.appendLine(`Running file: ${srcPath}`);
+  dbgOutputChannel.show(true);
+  dbgOutputChannel.appendLine(`Running file: ${srcPath}`);
 
   const config = vs.workspace.getConfiguration('squirrel.codeRunner');
   let toolPath: string = config.get('fileName') || '';
@@ -54,7 +53,7 @@ export default function runDocumentCode() {
 
   exec(cmd, (error, stdout, stderr) => {
     if (error) {
-      channel.appendLine(stdout);
+      dbgOutputChannel.appendLine(stdout);
 
       const diagList: vs.Diagnostic[] = [];
       checkCompileError(diagList, stdout);
@@ -65,7 +64,7 @@ export default function runDocumentCode() {
       return;
     }
 
-    channel.appendLine(stdout);
-    channel.appendLine('');
+    dbgOutputChannel.appendLine(stdout);
+    dbgOutputChannel.appendLine('');
   });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import * as vs from 'vscode';
+
 const PATH_MAX = 50;
 const MAX_FRAGMENTS= 3;
 
@@ -72,3 +74,5 @@ export function truncatePath(path:string): string {
   const last = path.lastIndexOf('/', length - 1);
   return path.substr(0, PATH_MAX - length + last) + '…' + path.substr(last);
 }
+
+export const dbgOutputChannel = vs.window.createOutputChannel("Squirrel");


### PR DESCRIPTION
Instead of assuming that there is a static code analyzer with a fixed command line interface, allow to specify an arbitrary command line for a code checker tool.
Also assume that diagnostics output JSON is written to an external temporary file (more flexibility again).
This is needed to be able to migrate to a new analyzer and allow to switching between different tools which can include project-specific bindings and other features.