### PR TITLE
Fix syntax: make `class` and `enum` non-greedy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-s-quirrel",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-s-quirrel",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^10.17.19",
@@ -17,6 +17,12 @@
       "engines": {
         "vscode": "^1.43.0"
       }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "extraneous": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.8.0",
@@ -259,11 +265,15 @@
         "node": "*"
       }
     },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -295,11 +305,12 @@
         "node": ">=0.10.0"
       }
     },
-    "path-parse": {
+    "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.14.2",
@@ -406,6 +417,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-s-quirrel",
   "displayName": "(S)quirrel",
   "description": "Squirrel and Quirrel language support",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "mepsoid",
   "icon": "acorn.png",
   "license": "MIT",

--- a/syntaxes/squirrel.tmLanguage.json
+++ b/syntaxes/squirrel.tmLanguage.json
@@ -63,7 +63,7 @@
     },
 
     "class": {
-      "begin": "(?=class)",
+      "begin": "(?=\\bclass\\b)",
       "end": "(?<=\\})|(;)",
       "endCaptures": { "1": { "name": "punctuation.terminator.squirrel" } },
       "name": "meta.class.squirrel",
@@ -113,7 +113,7 @@
     },
 
     "enum": {
-      "begin": "(?=enum)",
+      "begin": "(?=\\benum\\b)",
       "end": "(?<=\\})|(;)",
       "endCaptures": { "1": { "name": "punctuation.terminator.squirrel" } },
       "name": "meta.enum.squirrel",
@@ -129,6 +129,15 @@
       "beginCaptures": { "1": { "name": "storage.type.class.squirrel" } },
       "end": "([_A-Za-z][\\w]*)",
       "endCaptures": { "1": { "name": "entity.name.type.class.squirrel" } },
+      "patterns": [
+        { "include": "#global" }
+      ]
+    },
+
+    "enum-name-post": {
+      "begin": "(?<=\\w)",
+      "end": "(\\{)",
+      "endCaptures": { "1": { "name": "punctuation.definition.block.begin.squirrel" } },
       "patterns": [
         { "include": "#global" }
       ]
@@ -268,7 +277,8 @@
           "begin": "(\\$\\\")",
           "beginCaptures": {
             "0": { "name": "string.quoted.double.squirrel" },
-            "1": { "name": "punctuation.definition.string.begin.squirrel" } },
+            "1": { "name": "punctuation.definition.string.begin.squirrel" }
+          },
           "end": "(\\\")",
           "endCaptures": {
             "0": { "name": "string.quoted.double.squirrel" },


### PR DESCRIPTION
This fixes highlighting breaking on expressions such as

  from "foo.nut" import classSomething

Also add missing definition for the "enum-name-post" that was declared but not implemented.